### PR TITLE
update: interactive session in IRBCluster

### DIFF
--- a/docs/Cluster_basics/Interactive.md
+++ b/docs/Cluster_basics/Interactive.md
@@ -4,29 +4,58 @@ The `interactive` command gives to the user an **interactive shell** in the clus
 
 ## Usage
 
-Once you enter the bbgcluster, you will see in the terminal `<username>@login01`. It is here where, if you want to be allocated to your own node, you can just run the command:
+There is a difference between running an interactive session within the BBGCluster or the IRB Cluster. Please select the tab accordingly to where you are working.
 
-```bash
-$ interactive
-```
+=== "BBG Cluster"
+    Once you enter the bbgcluster, you will see in the terminal `<username>@login01`. It is here where, if you want to be allocated to your own node, you can just run the command:
 
-If the `login01` has changed to `bbgn###` where `###` is the number identifying the current node.
+    ```bash
+    $ interactive
+    ```
 
-Apart from the basic use, there are optional arguments/flags for extra features:
+    If the `login01` has changed to `bbgn###` where `###` is the number identifying the current node.
+    
+    Apart from the basic use, there are optional arguments/flags for extra features:
+    
+    - `-c`: Number of CPU cores (default: 1)
+    - `-m`: Total amount of memory (GB) (default: 8 [GB])
+    - `-w`: Target node
+    - `-J`: Job name
+    - `-x`: Binary that you want to run interactively
+    - `-p`: specify queue (see [queues](https://bbglab.github.io/bbgwiki/Cluster_basics/queues/))
 
-```bash
-interactive [-c] [-m] [-w] [-J] [-x] [-p]
-```
+=== "IRB Cluster"
+    In order to run `interactive` command in the IRB cluster you need to tell your terminal where to find it first.
 
-- `-c`: Number of CPU cores (default: 1)
-- `-m`: Total amount of memory (GB) (default: 8 [GB])
-- `-w`: Target node
-- `-J`: Job name
-- `-x`: Binary that you want to run interactively
-- `-p`: specify queue (see [queues](https://bbglab.github.io/bbgwiki/Cluster_basics/queues/))
+    !!! warning "Installation"
+
+        The `interactive` script is located here: `/data/bbg/software/bin/interactive`. In order to have it always available from wherever directory you want to run it, you need to add the following to your `.bashrc`
+
+        ```bash
+            export PATH=/home/$USER/.local/bin/:/data/bbg/software/bin/:$PATH
+        ```
+
+    Once you enter the irbcluster, you will see in the terminal `<username>@irblogin01`. Here is where you'd need to allocate desired resources to start working. The command to run is the following:
+
+    ```bash
+    $ interactive
+    ```
+
+    If the `login01` has changed to `irbcn##` where `###` is the number identifying the current node.
+    
+    Apart from the basic use, there are optional arguments/flags for extra features:
+    
+    - `-c`: Number of CPU cores (default: 1)
+    - `-m`: Total amount of memory (GB) (default: 8 [GB])
+    - `-w`: Target node
+    - `-J`: Job name
+    - `-x`: Binary that you want to run interactively
+    - `-p`: specify queue (see [queues](https://bbglab.github.io/bbgwiki/Cluster_basics/queues/))
+    - `-q`: specify the QoS (see [slides](https://bbgcloud.irbbarcelona.org/f/559435))
 
 ## Reference
 
+- Federica Brando
 - Jordi Deu-Pons
 - Miguel Grau
 - Carlos López-Elorduy

--- a/docs/Cluster_basics/Interactive.md
+++ b/docs/Cluster_basics/Interactive.md
@@ -41,7 +41,7 @@ There is a difference between running an interactive session within the BBGClust
     $ interactive
     ```
 
-    If the `login01` has changed to `irbcn##` where `###` is the number identifying the current node.
+    If the `irblogin01` has changed to `irbcn##` where `###` is the number identifying the current node.
     
     Apart from the basic use, there are optional arguments/flags for extra features:
     
@@ -50,7 +50,7 @@ There is a difference between running an interactive session within the BBGClust
     - `-w`: Target node
     - `-J`: Job name
     - `-x`: Binary that you want to run interactively
-    - `-p`: specify queue (see [queues](https://bbglab.github.io/bbgwiki/Cluster_basics/queues/))
+    - `-p`: specify queue (see [queues](https://bbglab.github.io/bbgwiki/Cluster_basics/queues/)) (default: `bbg_cpu_zen4`)
     - `-q`: specify the QoS (see [slides](https://bbgcloud.irbbarcelona.org/f/559435))
 
 ## Reference


### PR DESCRIPTION
This pull request includes updates to the `docs/Cluster_basics/Interactive.md` file to provide clearer instructions for running interactive sessions on the BBG and IRB clusters. The most important changes include the addition of tabs for cluster-specific instructions and new optional arguments/flags for the `interactive` command.

Cluster-specific instructions:

* Added a tabbed interface to differentiate between running an interactive session on the BBG Cluster and the IRB Cluster, providing specific instructions for each environment.

Optional arguments/flags:

* Included new optional arguments/flags for the `interactive` command, such as specifying the number of CPU cores, memory, target node, job name, binary to run, queue, and QoS.