### PR TITLE
Integrated the BBG dashboard learning part to the different subsectio…

### DIFF
--- a/docs/Plots_and_scripts/Advice-Tips_data_visualization
+++ b/docs/Plots_and_scripts/Advice-Tips_data_visualization
@@ -1,0 +1,22 @@
+# Advice/Tips data visualization
+
+### Points of view presentation: [link](https://docs.google.com/presentation/d/1HvGeGT9NBhVc0SKlyTx5Fae_4aTbyyfjVA7LIUvFBZA/edit#slide=id.p) 
+Covering
+- Layout
+- Gestalt principles (how people organize visual information)
+- Color usage
+- Plot specific parts
+    - Heatmaps
+    - Networks
+- Plot horrors
+
+
+### BBGallery of plots (legacy from BBGcloud)
+- [BBGplots](https://bbgcloud.irbbarcelona.org/dashboard/bggallery/bbgplots/index.html)
+- [Matplotlib](https://bbgcloud.irbbarcelona.org/dashboard/bggallery/examples_mpl/index.html)
+- [Bokeh](https://bbgcloud.irbbarcelona.org/dashboard/bggallery/examples_bkh/index.html) 
+
+
+
+## Reference
+- Axel Rosendahl Huber

--- a/docs/Tools/Programming/python/python_resources.md
+++ b/docs/Tools/Programming/python/python_resources.md
@@ -4,7 +4,7 @@ Set of useful Python resources as listed on the [BBGcloud Dashboard](https://bbg
 #### Coding basics
 
 [Get started with Python](https://bbgcloud.irbbarcelona.org/dashboard/python/index.html) - 
-Python tutorial covering the basis of Python 
+Python tutorial covering the basics of Python
 
 [Good coding practices](https://bbgcloud.irbbarcelona.org/dashboard/goodpractices/index.html) - Good practices for the BBLab coders
 

--- a/docs/Tools/Programming/python/python_resources.md
+++ b/docs/Tools/Programming/python/python_resources.md
@@ -1,0 +1,26 @@
+# Python Resources
+Set of useful Python resources as listed on the [BBGcloud Dashboard](https://bbgcloud.irbbarcelona.org/apps/external) _Learning_ platform
+
+#### Coding basics
+
+[Get started with Python](https://bbgcloud.irbbarcelona.org/dashboard/python/index.html) - 
+Python tutorial covering the basis of Python 
+
+[Good coding practices](https://bbgcloud.irbbarcelona.org/dashboard/goodpractices/index.html) - Good practices for the BBLab coders
+
+
+#### More specific topics: 
+
+[Python Classes](http://nbviewer.jupyter.org/urls/bitbucket.org/bgframework/bgschool/raw/master/python/notebooks/classes.ipynb) - 
+Tutorial on Python classes 
+
+[Write docs](https://bbgcloud.irbbarcelona.org/dashboard/docs/index.html)
+ Create **documentation** for your project using Sphinx 
+
+[Python Decorators](https://docs.google.com/presentation/d/17nwq5Og14bborFSgAnapjrW-6-KIM9KJfm7hKE_KZU8/edit#slide=id.p)  - 
+Introduction to Python decorators
+
+
+## Reference
+- Axel Rosendahl Huber
+

--- a/docs/Tools/Singularity/Overview.md
+++ b/docs/Tools/Singularity/Overview.md
@@ -26,6 +26,9 @@ Containers built by ITS Research are stored in `/data/containers` and are suppor
 ## Further reading
 
 - [Singularity website](https://sylabs.io/guides/latest/user-guide/index.html)
+- [BBGcloud presentation on Singularity](https://docs.google.com/presentation/d/1D4ExctFpb2kiSGMQ5rOQ4ctw6lktloey1Ak6xD9ZQ38/edit#slide=id.p)  
+- [BBGcloud presentation on Linux and containers](https://docs.google.com/presentation/d/1FRRg5Rml8sIPgm6KLEIK-Avr7vAyE_0yIRVUFug0U3s/edit#slide=id.p)  
+
 - Running `singularity help` and `singularity CMD help` (replace `CMD` with a Singularity command, such as `run`)
 - Viewing the "singularity" manual page
 
@@ -33,4 +36,5 @@ Containers built by ITS Research are stored in `/data/containers` and are suppor
 
 - Jordi Deu-Pons
 - Miguel Grau
+- Axel Rosendahl Huber
 - Carlos López-Elorduy


### PR DESCRIPTION
…ns of the website. See issue #176 


Summary of the issue: 

I am working on this issue.

List of parts in the Learning section which need to be added (or are already in some other form in the github repository):
In a way, much of the learning section parts (which was a mixed bag of resources) is now distributed alongside multiple parts of the bbgwiki. Many of the presentations and tutorials (especially the home-made google slides presentations) are of high quality and very useful

    Get started with Python, Python classes,Python decorators,Good practices, Write documentation:
    -> moved to Tools/Programming/Python/Python_resources
    Git (already present at: "https://bbglab.github.io/bbgwiki/Tools/Programming/git/") - no changes
    Write docs: (was python-specific), placed in Tools/Programming/Python/Python_resources
    Singularity: Added presentation link to the "Further reading" part of the BBGwiki Tools/Singularity/Overview
    Linux & Containers: Added presentation link to the "Further reading" part of the BBGwiki Tools/Singularity/Overview
    Points of view: Moved to "Plots and scripts" -> Advice-Tips_data_visualization
    BBGgallery of plots: Moved to "Plots and scripts" -> Advice-Tips_data_visualization
