### PR TITLE
242 bbgwiki cluster basic add script to dynamically adapt paths for irbbbg clusters

### DIFF
--- a/docs/Cluster_basics/Dynamic_paths.md
+++ b/docs/Cluster_basics/Dynamic_paths.md
@@ -49,3 +49,7 @@ This way, you only need to define the path logic once and can reuse it throughou
 
 !!! info
     Keeping shared variables—like paths, pipeline run names, or directory names—in a single Python file that can be imported from other scripts or notebooks is a good practice. It helps avoid inconsistencies and reduces the risk of forgetting to update paths or values across multiple files.
+
+## Reference
+
+- Stefano Pellegrini

--- a/docs/Cluster_basics/Dynamic_paths.md
+++ b/docs/Cluster_basics/Dynamic_paths.md
@@ -1,5 +1,5 @@
     
-# Dynamic path configuration for IRB/BBG clusters
+# Dynamic path configuration
 
 To ensure compatibility when running scripts or notebooks across different clusters (IRB or BBG), you can use the following Python line to dynamically set the working directory based on the machine hostname:
 
@@ -9,14 +9,14 @@ import socket
 WORKSPACE = "/data/bbg" if socket.gethostname().startswith("irb") else "/workspace"
 ```
 
-> [!WARNING]
-> This step is highly time- and resource-intensive, requiring a significant amount of free disk space and computational power. It will download and process a large amount of data. Ensure sufficient resources are available before proceeding, as insufficient capacity may result in extended runtimes or processing failures.
+!!! warning
+    This line assumes the script is being executed on a working node, where the hostname reflects the actual compute environment. It will not work if you are on the login node, which you shouldn't be using for computation in any case.
 
 ## How to Use
 
 ### Option 1: directly in a notebook or script
 
-Add the above line at the top of your notebook or Python script:
+Add the above line at the top of your Jupyter notebook or Python script:
 
 ```python
 import socket
@@ -27,10 +27,9 @@ example_path = f"{WORKSPACE}/projects/my_project/"
 print(f"Path: {example_path}")
 ```
 
-### Option 2: Using a `global_variables.py` file
-For better reusability, define this variable in a file named global_variables.py:
+### Option 2: Using a file including global variables
+For better reusability, define this variable in a separate Python file (e.g., `global_variables.py`):
 
-`global_variables.py`
 ```python
 import socket
 
@@ -47,3 +46,6 @@ print(f"Path: {example_path}")
 ```
 
 This way, you only need to define the path logic once and can reuse it throughout your codebase.
+
+!!! info
+    Keeping shared variables—like paths, pipeline run names, or directory names—in a single Python file that can be imported from other scripts or notebooks is a good practice. It helps avoid inconsistencies and reduces the risk of forgetting to update paths or values across multiple files.

--- a/docs/Cluster_basics/Dynamic_paths.md
+++ b/docs/Cluster_basics/Dynamic_paths.md
@@ -1,0 +1,49 @@
+    
+# Dynamic path configuration for IRB/BBG clusters
+
+To ensure compatibility when running scripts or notebooks across different clusters (IRB or BBG), you can use the following Python line to dynamically set the working directory based on the machine hostname:
+
+```python
+import socket
+
+WORKSPACE = "/data/bbg" if socket.gethostname().startswith("irb") else "/workspace"
+```
+
+> [!WARNING]
+> This step is highly time- and resource-intensive, requiring a significant amount of free disk space and computational power. It will download and process a large amount of data. Ensure sufficient resources are available before proceeding, as insufficient capacity may result in extended runtimes or processing failures.
+
+## How to Use
+
+### Option 1: directly in a notebook or script
+
+Add the above line at the top of your notebook or Python script:
+
+```python
+import socket
+
+WORKSPACE = "/data/bbg" if socket.gethostname().startswith("irb") else "/workspace"
+
+example_path = f"{WORKSPACE}/projects/my_project/"
+print(f"Path: {example_path}")
+```
+
+### Option 2: Using a `global_variables.py` file
+For better reusability, define this variable in a file named global_variables.py:
+
+`global_variables.py`
+```python
+import socket
+
+WORKSPACE = "/data/bbg" if socket.gethostname().startswith("irb") else "/workspace"
+```
+
+Then, import it in your notebook or script:
+
+```python
+from global_variables import WORKSPACE
+
+example_path = f"{WORKSPACE}/projects/my_project/"
+print(f"Path: {example_path}")
+```
+
+This way, you only need to define the path logic once and can reuse it throughout your codebase.


### PR DESCRIPTION
This PR adds a new wiki page (Dynamic path configuration) to the Cluster Basics explaining how to dynamically configure the paths based on the cluster environment (IRB or BBG).

### Key points covered:

* How to use `socket.gethostname()` to set the path dynamically
* Where to place this logic (directly in scripts or via an importable file)
* Importance of running on a working node
* Recommendation to centralize shared variables in a single file (e.g., `global_variables.py`) to improve maintainability