### PR TITLE
Fix issue template title formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bbgwiki---hackathon-issue-type.md
+++ b/.github/ISSUE_TEMPLATE/bbgwiki---hackathon-issue-type.md
@@ -7,8 +7,9 @@ assignees: ''
 
 ---
 
-** Name the page you want to update/add/fix **
-- 
+**Name the page you want to update/add/fix**
+-
 
-** Describe very very briefly what you are doing**
+**Describe very very briefly what you are doing**
+
 - Updating/adding/fixing..

--- a/.github/ISSUE_TEMPLATE/bbgwiki---hackathon-issue-type.md
+++ b/.github/ISSUE_TEMPLATE/bbgwiki---hackathon-issue-type.md
@@ -1,7 +1,7 @@
 ---
 name: BBGwiki | hackathon issue type
 about: Template issue to track progress in hackathon
-title: BBGwiki | [update/add/fix
+title: BBGwiki | [update/add/fix]
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
This PR simply fixes the issue template title where a square bracket was opened but never closed.