### PR TITLE
209 other data context counts

### DIFF
--- a/docs/Datasets/Other_data/Trinucleotide_content.md
+++ b/docs/Datasets/Other_data/Trinucleotide_content.md
@@ -1,2 +1,15 @@
-# Trinucleotide content of the genome
+# Nucleotide content of the genome
 
+## Introduction
+
+The nucleotide content of the genome refers to the frequency and distribution of *n*-nucleotide sequences across the DNA. We most common count used is by trinucleotides. In principle, there are 4³ = 64 possible trinucleotide combinations, given the four DNA bases (A, C, G, and T). However, because DNA is double-stranded and sequences are often analyzed without strand specificity, many genomic analyses collapse reverse-complement pairs. As a result, the 64 trinucleotides are reduced to 32 unique trinucleotide contexts, with each context representing both a sequence and its reverse complement.
+
+It is important to take into account the nucleotide content of the genome we are using when performing analysis that rely on the distribution of mutations across genomic positions, as the *n*-nucleotides are not equally represented. 
+
+## Where is this data stored in the cluster?
+
+This page aims to gather the nucleotide counts files stored in the cluster for several genomes and nucleotide combinations:
+- **Whole genome GRCh38 trinucleotide counts (32 channels)**
+    + Created by [Alexandrov Lab for SigProfiler](https://github.com/AlexandrovLab/SigProfilerMatrixGenerator/tree/master/SigProfilerMatrixGenerator/references/chromosomes/context_distributions)
+    + Stored at `/data/bbg/datasets/genomes/context_counts/sigprofiler/context_counts_GRCh38_96.csv`  
+    + Rows represent trinucleotides, columns chromosomes and cells are filled with the absolute trinucleotide count for the reference genome

--- a/docs/Datasets/Other_data/Trinucleotide_content.md
+++ b/docs/Datasets/Other_data/Trinucleotide_content.md
@@ -1,0 +1,2 @@
+# Trinucleotide content of the genome
+


### PR DESCRIPTION
This pull request adds a new subsection in the 'Other data' section in `docs/Datasets/Other_data/Trinucleotide_content.md`. This subsection includes:

- A brief explanation of what the genome content is in terms of nucleotide *n-mers*
- Highlights the importance of using this information to make adjustments between genomes that do not have the same nucleotide content.
- Gathers the paths to the cluster files that contain this information for several genomes (right now only hg38 whole genome)