### PR TITLE
Add STU to S3 documentation

### DIFF
--- a/docs/Cluster_basics/s3.md
+++ b/docs/Cluster_basics/s3.md
@@ -117,7 +117,7 @@ $ ls /home/mgrau/s3/bbg-scratch/
 $
 ```
 
-One your credentials are generated, you can use [stu](https://github.com/lusingander/stu) as a TUI explorer.
+Once your credentials are generated, you can use [stu](https://github.com/lusingander/stu) as a TUI explorer.
 
 ```bash
 spack load stu


### PR DESCRIPTION
This pull request updates the `docs/Cluster_basics/s3.md` file to reflect changes in S3 access policies and introduces a new tool for exploring S3 storage via the terminal. The most important changes include removing references to MinIO web access for IRB members, updating access instructions for terminal usage, and adding documentation for the `stu` TUI explorer.

### Updates to S3 access policies:
* Removed references to MinIO web access for IRB members, clarifying that this feature is now only available to users on paid plans. Updated instructions to emphasize terminal-based access for navigating S3 storage and executing pipelines.
* Removed the "Minio Web" section entirely, including login instructions and example images.

### Enhancements to terminal-based S3 usage:
* Added documentation for using `stu`, a terminal-based TUI explorer for S3 storage, including installation instructions and a demonstration image.

### Table of contents adjustments:
* Removed the "Minio-web" subsection from the table of contents to align with the updated content.