### PR TITLE
Add pymdownx.tilde extension for strikethrough and subscript support

### DIFF
--- a/docs/Cluster_basics/s3.md
+++ b/docs/Cluster_basics/s3.md
@@ -2,12 +2,17 @@
 
 ## Table of Contents
 
-- [What is a S3 Storage](#what-is-a-s3-storage)
-- [How to access](#how-to-access)
+- [S3 storage](#s3-storage)
+  - [Table of Contents](#table-of-contents)
+  - [What is a S3 Storage?](#what-is-a-s3-storage)
+  - [How to access](#how-to-access)
     - [Terminal](#terminal)
-- [How to use it](#how-to-use-it)
+  - [How to use it](#how-to-use-it)
     - [Seqera and Nextflow](#seqera-and-nextflow)
     - [Python](#python)
+      - [boto3](#boto3)
+      - [s3fs](#s3fs)
+      - [dask](#dask)
 
 ## What is a S3 Storage?
 
@@ -117,7 +122,8 @@ $ ls /home/mgrau/s3/bbg-scratch/
 $
 ```
 
-Once your aws credentials are generated, you can use [stu](https://github.com/lusingander/stu) as a TUI explorer. You don't need to mount the S3 bucket:
+Once your aws credentials are generated, you can use [stu](https://github.com/lusingander/stu) as a TUI explorer.
+You don't need to mount the S3 bucket:
 
 ```bash
 spack load stu
@@ -208,7 +214,7 @@ import s3fs
 
 # Read the file using Dask (with appropriate filters)
 df = dd.read_csv("s3://bbg/data/example/file.vcf",
-                 sep='\t', 
+                 sep='\t',
                  comment='#',  # Ignore metadata lines starting with `##`
                  blocksize='16MB',  # Adjust block size as needed
                  dtype='str')  # Ensures flexible data type handling

--- a/docs/Cluster_basics/s3.md
+++ b/docs/Cluster_basics/s3.md
@@ -3,16 +3,16 @@
 ## Table of Contents
 
 - [S3 storage](#s3-storage)
-  - [Table of Contents](#table-of-contents)
-  - [What is a S3 Storage?](#what-is-a-s3-storage)
-  - [How to access](#how-to-access)
-    - [Terminal](#terminal)
-  - [How to use it](#how-to-use-it)
-    - [Seqera and Nextflow](#seqera-and-nextflow)
-    - [Python](#python)
-      - [boto3](#boto3)
-      - [s3fs](#s3fs)
-      - [dask](#dask)
+    - [Table of Contents](#table-of-contents)
+    - [What is a S3 Storage?](#what-is-a-s3-storage)
+    - [How to access](#how-to-access)
+        - [Terminal](#terminal)
+    - [How to use it](#how-to-use-it)
+        - [Seqera and Nextflow](#seqera-and-nextflow)
+        - [Python](#python)
+            - [boto3](#boto3)
+            - [s3fs](#s3fs)
+            - [dask](#dask)
 
 ## What is a S3 Storage?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ theme:
       primary: orange
       accent: deep_orange
       toggle:
-        icon: material/brightness-7 
+        icon: material/brightness-7
         name: Switch to dark mode
 
     # Palette toggle for dark mode
@@ -27,7 +27,7 @@ theme:
   favicon: assets/images/bbglabLOGO_small.png
   icon:
     repo: fontawesome/brands/git-alt
-    edit: material/pencil 
+    edit: material/pencil
     view: material/eye
   features:
     - navigation.top
@@ -36,7 +36,7 @@ theme:
     - content.action.edit
     - content.action.view
 
-plugins: 
+plugins:
   - search
   - tags
   - git-committers:
@@ -58,10 +58,11 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.details
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.tilde:
 
 extra_css:
   - stylesheets/extra.css
@@ -69,7 +70,7 @@ extra_css:
 extra:
   consent:
     title: Cookie consent
-    description: >- 
+    description: >-
       We use cookies to recognize your repeated visits and preferences, as well
       as to measure the effectiveness of our documentation and whether users
       find what they're searching for. With your consent, you're helping us to
@@ -88,6 +89,6 @@ extra:
         - icon: octicons/bug-16
           name: This page could be improved
           data: 0
-          note: >- 
+          note: >-
             Thanks for your feedback! Help us improve this page by
             using our <a href="https://github.com/bbglab/bbgwiki/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">feedback form</a>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - pymdownx.tilde:
+  - pymdownx.tilde
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
## Summary
This PR adds support for strikethrough and subscript text formatting in the BBG-Wiki by implementing the `pymdownx.tilde` extension.

## Changes
- ✅ Added `pymdownx.tilde:` extension to `mkdocs.yml`
- ✅ Fixed trailing whitespace issues in configuration file
- ✅ Enables `~~strikethrough~~` and `~subscript~` text formatting

## Testing
The extension has been added to the markdown_extensions configuration and should work with standard tilde notation.

Closes #283