### PR TITLE
Update Google Form link in archiving instructions

### DIFF
--- a/docs/BBGProtocols/BBGlab_computer_setup.md
+++ b/docs/BBGProtocols/BBGlab_computer_setup.md
@@ -1,6 +1,6 @@
 # New member computer setup
 
-Welcome to the BBG lab! Here's a checklist that will guide you through getting your computer set up. 
+Welcome to the BBG lab! Here's a checklist that will guide you through getting your computer set up.
 
 1. Download or set up:
     - forticlient VPN
@@ -8,7 +8,7 @@ Welcome to the BBG lab! Here's a checklist that will guide you through getting y
     - .bashrc
     - LibreOffice (open access version of Microsoft Office)
 2. Engineering team will give you access to:
-    - Slack 
+    - Slack
     - BBGlab organization on Github (make your account if you don't have one already)
     - bbgcloud (Nextcloud)
     - Google group: ITS-BBG
@@ -18,7 +18,7 @@ Welcome to the BBG lab! Here's a checklist that will guide you through getting y
           intranet documentation from IRB ITS
 3. You'll also get an introduction to the cluster, with regards to accessing it and the
    file structure that's relevant for your project. You'll need to be given access and
-   permissions for the following things: 
+   permissions for the following things:
     - slurm (apply for account via IT)
     - write permissions in the cluster directories you work with
     - Seqera BBG group

--- a/docs/BBGProtocols/BBGlab_new_protocol.md
+++ b/docs/BBGProtocols/BBGlab_new_protocol.md
@@ -29,7 +29,8 @@ Remember to follow the
 when organizing your project directory.
 In addition, you should create a copy of the **Project Compilation spreadsheet** with your name,
 fill it up with the information of your project/s and keep updating it whenever needed.
-Please find the [Project Compilation files](https://drive.google.com/drive/folders/14SS8kvBcCrPsdwg3ETbTn-c9Erwu702a) here.
+Please find the [Project Compilation files](
+    https://drive.google.com/drive/folders/14SS8kvBcCrPsdwg3ETbTn-c9Erwu702a) here.
 
 ## Properly organize your google drive
 

--- a/docs/BBGProtocols/BBglab_data_organization.md
+++ b/docs/BBGProtocols/BBglab_data_organization.md
@@ -9,15 +9,23 @@ the **[BBGlab Exit protocol](https://drive.google.com/file/d/1BnhLZCygroJ-dfamuZ
 
 You MUST add all the relevant information about your finished or ongoing project in:
 
-1. **Project Compilation file**: this file indicates all the paths in the cluster that you have been working in across all your projects. For that:
-    1. Copy the **[Project Compilation template](https://docs.google.com/spreadsheets/d/1jJleTek9eP4S6CCe5fO8_M4-vLuKhumgKjlQ58jP_rc/edit?gid=0#gid=0)** and store it in the [Projects Personal Spreadsheet folder](https://drive.google.com/drive/folders/14SS8kvBcCrPsdwg3ETbTn-c9Erwu702a?usp=drive_link). It should be one file per BBGlab member stored.
+1. **Project Compilation file**: this file indicates all the paths in the cluster that you have been working in
+    across all your projects. For that:
+    1. Copy the
+**[Project Compilation template](
+    https://docs.google.com/spreadsheets/d/1jJleTek9eP4S6CCe5fO8_M4-vLuKhumgKjlQ58jP_rc/edit?gid=0#gid=0)**
+     and store it in the
+     [Projects Personal Spreadsheet folder](
+        https://drive.google.com/drive/folders/14SS8kvBcCrPsdwg3ETbTn-c9Erwu702a?usp=drive_link)
+     . It should be one file per BBGlab member stored.
     2. Change the name of the document with your information as follow: `ProjectCompilation-202X-NameSurname`
     3. Modify the document by removing the rows showing the examples and add your own entries.
 
-2. **[BBGlab datasets file](https://bbglab.github.io/bbgwiki/Datasets/Datasets_BBGLAB/)**: includes all the information about the datasets we use (both internal or external).
+2. **[BBGlab datasets file](https://bbglab.github.io/bbgwiki/Datasets/Datasets_BBGLAB/)**: includes all the information
+    about the datasets we use (both internal or external).
 
-> **It is essential to fill all these files so that all your project data is updated and stored. It is the
-> responsibility of ALL the users involved in the project to keep it updated!**
+> **It is essential to fill all these files so that all your project data is updated and stored.
+> It is the responsibility of ALL the users involved in the project to keep it updated!**
 
 Organize your project directories with this basic structure:
 

--- a/docs/Datasets/Archive_data.md
+++ b/docs/Datasets/Archive_data.md
@@ -5,7 +5,7 @@ Any folder in the cluster that we think should be archived we have to communicat
 ## Description
 
 We have [this google form](
-https://docs.google.com/forms/d/e/1FAIpQLSdAGooKCttwBWhTyfplFby8aRI1G4qAGepZKBZ-8RHxLM-kjA/viewform?usp=dialo
+https://docs.google.com/forms/d/e/1FAIpQLSdAGooKCttwBWhTyfplFby8aRI1G4qAGepZKBZ-8RHxLM-kjA/viewform?usp=dialog
 )
 to annotate any folder/dataset we want to archive.  
 This way Miguel has a follow up table with all the listed data pending to archive.

--- a/docs/Datasets/Archive_data.md
+++ b/docs/Datasets/Archive_data.md
@@ -4,7 +4,7 @@ Any folder in the cluster that we think should be archived we have to communicat
 
 ## Description
 
-We have [this google form](https://forms.gle/YNqdYYoaGvVcSyfE6)
+We have [this google form](https://docs.google.com/forms/d/e/1FAIpQLSdAGooKCttwBWhTyfplFby8aRI1G4qAGepZKBZ-8RHxLM-kjA/viewform?usp=dialo)
 to annotate any folder/dataset we want to archive.  
 This way Miguel has a follow up table with all the listed data pending to archive.
 

--- a/docs/Datasets/Archive_data.md
+++ b/docs/Datasets/Archive_data.md
@@ -4,7 +4,9 @@ Any folder in the cluster that we think should be archived we have to communicat
 
 ## Description
 
-We have [this google form](https://docs.google.com/forms/d/e/1FAIpQLSdAGooKCttwBWhTyfplFby8aRI1G4qAGepZKBZ-8RHxLM-kjA/viewform?usp=dialo)
+We have [this google form](
+https://docs.google.com/forms/d/e/1FAIpQLSdAGooKCttwBWhTyfplFby8aRI1G4qAGepZKBZ-8RHxLM-kjA/viewform?usp=dialo
+)
 to annotate any folder/dataset we want to archive.  
 This way Miguel has a follow up table with all the listed data pending to archive.
 


### PR DESCRIPTION
This pull request makes minor formatting improvements to several documentation files by breaking up long URLs across multiple lines for better readability and consistency. There are no content changes.

Documentation formatting improvements:

* Broke up long Google Drive and Google Forms URLs onto separate lines in `BBGlab_new_protocol.md`, `BBglab_data_organization.md`, and `Archive_data.md` for improved readability. [[1]](diffhunk://#diff-bccee231b48366587f7b97ded9585c361e44e473c6ae7e84cf0d4c21b12f4fc7L32-R33) [[2]](diffhunk://#diff-4cfce58a42ea125f35e9588e6fb868df4d385f69b2b21f78f26515b79e5b1263L12-R28) [[3]](diffhunk://#diff-661785b724bd5745fd1cd8fb9cf4ca6dd38e3bcc6ad80e9d881fe0530eea8556L7-R9)