### PR TITLE
fix: update path and name

### DIFF
--- a/docs/Cluster_basics/s3.md
+++ b/docs/Cluster_basics/s3.md
@@ -80,7 +80,7 @@ $ conda activate s3-minio
 $ python3 /apps/scripts/irb-storage-public-scripts/minio-sts-credentials-request.py -u mgrau -r -d 365
 
 # test
-$ rclone lsf irbminio://bbg
+$ rclone lsf irbminio:bbg
 ```
 
 This script (*minio-sts-credentials-request.py*) generates the config file used by rclone:

--- a/docs/Cluster_basics/s3.md
+++ b/docs/Cluster_basics/s3.md
@@ -77,10 +77,10 @@ $ conda activate s3-minio
 # Generate credentials
 # -r -> creates the ~/.config/rclone/rclone.conf file
 # -d -> duration in days for credentials validity
-$ python3 /apps/scripts/irb-storage-public-scripts/minio/minio-sts-credentials-request.py -u mgrau -r -d 365
+$ python3 /apps/scripts/irb-storage-public-scripts/minio-sts-credentials-request.py -u mgrau -r -d 365
 
 # test
-$ rclone lsf irb-minio://bbg
+$ rclone lsf irbminio://bbg
 ```
 
 This script (*minio-sts-credentials-request.py*) generates the config file used by rclone:
@@ -88,7 +88,7 @@ This script (*minio-sts-credentials-request.py*) generates the config file used 
 ```bash
 $ cat ~/.config/rclone/rclone.conf
 
-[irb-minio]
+[irbminio]
 type = s3
 provider = Minio
 endpoint = http://irbminio.irbbarcelona.pcb.ub.es:9000
@@ -121,13 +121,13 @@ As mentioned earlier, you can mount an S3 bucket as a POSIX-like partition (simi
 ```bash
 $ ls /home/mgrau/s3/bbg-scratch/
 # Mount
-$ rclone mount irb-minio:bbg-scratch /home/mgrau/s3/bbg-scratch --vfs-cache-mode off --read-only &
+$ rclone mount irbminio:bbg-scratch /home/mgrau/s3/bbg-scratch --vfs-cache-mode off --read-only &
 [1] 636085
 $ ls /home/mgrau/s3/bbg-scratch/
 work
 # Unmount
 $ fusermount -u /home/mgrau/s3/bbg-scratch
-[1]+  Done                    rclone mount irb-minio:bbg-scratch /home/mgrau/s3/bbg-scratch
+[1]+  Done                    rclone mount irbminio:bbg-scratch /home/mgrau/s3/bbg-scratch
 --vfs-cache-mode off --read-only
 $ ls /home/mgrau/s3/bbg-scratch/
 $


### PR DESCRIPTION
This pull request updates the S3 documentation to match the naming of the rclone remote from `irb-minio` to the `irbminio` currently used.

It also updates the path to the credentials' generation script.